### PR TITLE
Increase lighthouse numberOfruns

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "numberOfRuns": 1,
+      "numberOfRuns": 3,
       "settings": {
         "chromeFlags": ["--ignore-certificate-errors"]
       }


### PR DESCRIPTION
We're currently using a `numberOfRuns` of `1`. Increasing it to `5` may greatly reduce the impact of variability at measure time, as per hinted [in the official documentation](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md#numberofruns).