### PR TITLE
Ajoute Pix.fr et Pix App au SeigneurTiret a.k.a. DashLord

### DIFF
--- a/urls.txt
+++ b/urls.txt
@@ -4,6 +4,7 @@ https://adock.beta.gouv.fr
 https://aidantsconnect.beta.gouv.fr
 https://aides-territoires.beta.gouv.fr
 https://aplus.beta.gouv.fr
+https://app.pix.fr
 https://audioconf.numerique.gouv.fr
 https://beta.gouv.fr
 https://blog.beta.gouv.fr
@@ -32,6 +33,7 @@ https://openfisca.mes-aides.1jeune1solution.beta.gouv.fr
 https://pad.incubateur.net
 https://partaj.beta.gouv.fr
 https://pilotage.inclusion.beta.gouv.fr
+https://pix.fr
 https://place-des-entreprises.beta.gouv.fr
 https://potentiel.beta.gouv.fr
 https://rdv-solidarites.fr


### PR DESCRIPTION
Pour rappel (Slack #incubateur-holodeck, 19/04/2021, 9:43PM) :
> Pour info, je suis en train de faire la PR pour ajouter Pix. Pour info, nous gérons plusieurs websites/webapps. Je n’ai pas envie de polluer le holodeck. Je vais me contenter dans un premier temps du site principal (pix.fr) et de l’appli principale (app.pix.fr) à destination des usagers grand public. Concernant cette dernière (SPA Ember.js), j’ai une petite crainte, dans la mesure où elle nécessite d’être authentifié pour passer l’écran de login (incorporé à l’app, mais bientôt géré via une instance Keycloak).